### PR TITLE
Enabling command line usage, and make it less dependent of IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,9 @@ Now we have the StepDefs.kt file and we can start implementing the steps, as wel
 ## Add JUnit runner
 
 To run our features from a JUnit runner, we’ll need to add one. In the `src/test/kotlin` folder, we add a new Kotlin File/Class, called RunKukesTest.
+
+## Running tests from the command line
+
+To run all tests use
+
+    mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
     </dependencies>
 
     <build>
+
+    <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
@@ -67,6 +71,8 @@
             </plugin>
         </plugins>
     </build>
+
+
 
 
 </project>


### PR DESCRIPTION
As a developer who does not use IntelliJ 
I want to be able to run tests using the command line
So that I do not have to download IntelliJ

This is also required if it should run in a Build Pipeline / Continuous Integration tool, such as CircleCI or similar. 

I added references to the Kotlin folder in the POM.XML file 

See updates in the readme.md file.